### PR TITLE
bump base operating system to RHEL 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # base operating system image purpose built for containers. For more information
 # see https://developers.redhat.com/products/rhel/ubi
 #
-FROM registry.access.redhat.com/ubi8/ubi:8.1
+FROM registry.access.redhat.com/ubi8/ubi:8.2
 USER root
 
 ARG container_version


### PR DESCRIPTION
Bumping Dockerfile to use RHEL 8.2

Documentation reference:
https://falcon.crowdstrike.com/support/documentation/20/falcon-sensor-for-linux#operating-systems

